### PR TITLE
Add .artignore support

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,27 @@ Please see [the command reference](./docs/commands/art.md)
 
 
 ## Configurations
+
+### Ignore file
+Just like git, you can put a `.artignore` file at the root of workspace to define the excluding list. The rule is a regular expression of path. Here is the example
+
+```
+# Each line defines a regular expression rule
+
+# Ignore files
+^test$
+^path/to/my/file$
+\.DS_Store$
+
+# Ignore folders. Use a forward slash at the end
+^build/
+^path/to/my/folder/
+/build/
+
+# Ignore all file with extension '.py'
+\.py$
+````
+
 ### S3 repository
 Prepare the `~/.aws/credentials` to access the s3 repository. Please see the [AWS documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)
 

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -235,6 +235,10 @@ func NewArtIgnore(dir string) ArtIgnore {
 	for scanner.Scan() {
 		text := strings.TrimSpace(scanner.Text())
 
+		if len(text) == 0 {
+			continue
+		}
+
 		// skip # comment line
 		if strings.IndexAny(text, "#") == 0 {
 			continue

--- a/internal/core/manager.go
+++ b/internal/core/manager.go
@@ -304,9 +304,17 @@ func (mngr *ArtifactManager) Push(options PushOptions) error {
 		return err
 	}
 
+	artIgnore := NewArtIgnore(mngr.baseDir)
+	artIgnoreFilter := func(path string) bool {
+		return !artIgnore.ShouldIgnore(path)
+	}
+
 	result, err := mngr.Diff(DiffOptions{
-		LeftRef:     RefLatest,
-		RightCommit: commit,
+		LeftRef:      RefLatest,
+		RightCommit:  commit,
+		AddFilter:    artIgnoreFilter,
+		ChangeFilter: artIgnoreFilter,
+		DeleteFilter: nil,
 	})
 	if err != nil {
 		if err != ErrEmptyRepository {
@@ -314,8 +322,11 @@ func (mngr *ArtifactManager) Push(options PushOptions) error {
 		} else {
 			checkSkip = false
 			result, err = mngr.Diff(DiffOptions{
-				LeftCommit:  mngr.MakeEmptyCommit(),
-				RightCommit: commit,
+				LeftCommit:   mngr.MakeEmptyCommit(),
+				RightCommit:  commit,
+				AddFilter:    artIgnoreFilter,
+				ChangeFilter: artIgnoreFilter,
+				DeleteFilter: nil,
 			})
 			if err != nil {
 				return err
@@ -447,7 +458,7 @@ func (mngr *ArtifactManager) MakeWorkspaceCommit(parent string, message *string)
 			}
 
 			path := absPath[len(baseDir)+1:]
-			if strings.HasPrefix(path, ".art") {
+			if strings.HasPrefix(path, ".art/") {
 				return nil
 			}
 
@@ -531,10 +542,18 @@ func (mngr *ArtifactManager) Pull(options PullOptions) error {
 	}
 
 	// Diff
+	artIgnore := NewArtIgnore(mngr.baseDir)
+	artIgnoreFilter := func(path string) bool {
+		return !artIgnore.ShouldIgnore(path)
+	}
+
 	result, err := mngr.Diff(DiffOptions{
-		Mode:        options.Mode,
-		LeftCommit:  commitLocal,
-		RightCommit: commitRemote,
+		Mode:         options.Mode,
+		LeftCommit:   commitLocal,
+		RightCommit:  commitRemote,
+		AddFilter:    artIgnoreFilter,
+		ChangeFilter: artIgnoreFilter,
+		DeleteFilter: artIgnoreFilter,
 	})
 	if err != nil {
 		return err
@@ -721,6 +740,8 @@ func (mngr *ArtifactManager) Diff(option DiffOptions) (DiffResult, error) {
 	var commitHash string
 	var err error
 
+	// Step 1: Prepare the left and right commits
+
 	// left
 	leftCommit := option.LeftCommit
 	if leftCommit == nil {
@@ -760,12 +781,9 @@ func (mngr *ArtifactManager) Diff(option DiffOptions) (DiffResult, error) {
 		entries[blob.Path] = entry
 	}
 
-	// Merge the "added" and "deleted" with the same content to "renamed".
-	// key: hash
-	// value: {type, path, newPath}
+	// Step 2: Compare left and right and create the changesets (added, delelete, changed)
 	mapAdded := map[string][]DiffRecord{}
 	mapDeleted := map[string][]DiffRecord{}
-	mapRenamed := map[string][]DiffRecord{}
 	mapChanged := map[string][]DiffRecord{}
 
 	appendOrMake := func(s []DiffRecord, item DiffRecord) []DiffRecord {
@@ -776,26 +794,43 @@ func (mngr *ArtifactManager) Diff(option DiffOptions) (DiffResult, error) {
 		}
 	}
 
-	artIgnore := NewArtIgnore(mngr.baseDir)
-
 	for path, entry := range entries {
 		if entry.left == nil && entry.right != nil {
-			// ignore added when the path is ignored
-			if !artIgnore.ShouldIgnore(path) {
-				record := DiffRecord{Type: DiffTypeAdd, Path: entry.right.Path, Hash: entry.right.Hash}
-				mapAdded[entry.right.Hash] = appendOrMake(mapAdded[entry.right.Hash], record)
+			if option.AddFilter != nil {
+				if !option.AddFilter(path) {
+					continue
+				}
 			}
+
+			record := DiffRecord{Type: DiffTypeAdd, Path: entry.right.Path, Hash: entry.right.Hash}
+			mapAdded[entry.right.Hash] = appendOrMake(mapAdded[entry.right.Hash], record)
 		} else if entry.left != nil && entry.right == nil {
-			if option.Mode != ChangeModeMerge {
-				record := DiffRecord{Type: DiffTypeDelete, Path: entry.left.Path, Hash: entry.left.Hash}
-				mapDeleted[entry.left.Hash] = appendOrMake(mapDeleted[entry.left.Hash], record)
+			if option.Mode == ChangeModeMerge {
+				continue
 			}
+
+			if option.DeleteFilter != nil {
+				if !option.DeleteFilter(path) {
+					continue
+				}
+			}
+
+			record := DiffRecord{Type: DiffTypeDelete, Path: entry.left.Path, Hash: entry.left.Hash}
+			mapDeleted[entry.left.Hash] = appendOrMake(mapDeleted[entry.left.Hash], record)
 		} else if entry.left.Hash != entry.right.Hash {
+			if option.ChangeFilter != nil {
+				if !option.ChangeFilter(path) {
+					continue
+				}
+			}
+
 			record := DiffRecord{Type: DiffTypeChange, Path: entry.left.Path, Hash: entry.left.Hash}
 			mapChanged[entry.left.Hash] = appendOrMake(mapChanged[entry.left.Hash], record)
 		}
 	}
 
+	// Step3: Merge "added" and "deleted" with the same content hash to "rename"
+	mapRenamed := map[string][]DiffRecord{}
 	for hash, addedPaths := range mapAdded {
 		deleledPaths := mapDeleted[hash]
 		if deleledPaths == nil {
@@ -825,7 +860,7 @@ func (mngr *ArtifactManager) Diff(option DiffOptions) (DiffResult, error) {
 		mapRenamed[hash] = renamedRecords
 	}
 
-	// Merge the records from map
+	// Step 4: Merge the the 4 maps to the diff record list
 	records := []DiffRecord{}
 	var conflict bool
 	for _, added := range mapAdded {

--- a/internal/core/manager_test.go
+++ b/internal/core/manager_test.go
@@ -9,12 +9,11 @@ import (
 )
 
 func TestPutGet(t *testing.T) {
-	tempDir := t.TempDir()
-	wp1 := tempDir + "/wp1"
-	meta1 := tempDir + "/meta1"
-	wp2 := tempDir + "/wp2"
-	meta2 := tempDir + "/meta2"
-	repo := tempDir + "/repo"
+	wp1 := t.TempDir()
+	meta1 := t.TempDir()
+	wp2 := t.TempDir()
+	meta2 := t.TempDir()
+	repo := t.TempDir()
 
 	path := "test"
 	content := "test-data"
@@ -42,10 +41,9 @@ func TestPutGet(t *testing.T) {
 }
 
 func TestPushPull(t *testing.T) {
-	t.TempDir()
-	wp1 := t.TempDir() + "/wp1"
-	wp2 := t.TempDir() + "/wp2"
-	repo := t.TempDir() + "/repo"
+	wp1 := t.TempDir()
+	wp2 := t.TempDir()
+	repo := t.TempDir()
 
 	path := "test"
 	content := "test-data"
@@ -70,18 +68,17 @@ func TestPushPull(t *testing.T) {
 }
 
 func TestPushWithIgnore(t *testing.T) {
-	t.TempDir()
-	wp1 := t.TempDir() + "/wp1"
-	wp2 := t.TempDir() + "/wp2"
-	repo := t.TempDir() + "/repo"
+	wp1 := t.TempDir()
+	wp2 := t.TempDir()
+	repo := t.TempDir()
 
 	writeFile([]byte("a"), filepath.Join(wp1, "a"))
 	writeFile([]byte("b"), filepath.Join(wp1, "b"))
 	writeFile([]byte("c"), filepath.Join(wp1, "c"))
 
 	artIgnore := `
-a
-e
+^a$
+^e$
 `
 
 	writeFile([]byte(artIgnore), filepath.Join(wp1, ".artignore"))
@@ -89,12 +86,14 @@ e
 	InitWorkspace(wp1, repo)
 	config, _ := LoadConfig(wp1)
 	mngr1, _ := NewArtifactManager(config)
-	mngr1.Push(PushOptions{})
+	err := mngr1.Push(PushOptions{})
+	assert.Empty(t, err)
 
 	InitWorkspace(wp2, repo)
 	config, _ = LoadConfig(wp2)
 	mngr2, _ := NewArtifactManager(config)
-	mngr2.Pull(PullOptions{})
+	err = mngr2.Pull(PullOptions{})
+	assert.Empty(t, err)
 
 	data, _ := readFile(filepath.Join(wp2, "a"))
 	assert.Equal(t, "", string(data))
@@ -105,10 +104,9 @@ e
 }
 
 func TestPullWithIgnore(t *testing.T) {
-	t.TempDir()
-	wp1 := t.TempDir() + "/wp1"
-	wp2 := t.TempDir() + "/wp2"
-	repo := t.TempDir() + "/repo"
+	wp1 := t.TempDir()
+	wp2 := t.TempDir()
+	repo := t.TempDir()
 
 	// push
 	writeFile([]byte("a"), filepath.Join(wp1, "a"))
@@ -117,12 +115,13 @@ func TestPullWithIgnore(t *testing.T) {
 	InitWorkspace(wp1, repo)
 	config, _ := LoadConfig(wp1)
 	mngr1, _ := NewArtifactManager(config)
-	mngr1.Push(PushOptions{})
+	err := mngr1.Push(PushOptions{})
+	assert.Empty(t, err)
 
 	// pull
 	artIgnore := `
-a
-e
+^a$
+^e$
 `
 	writeFile([]byte(artIgnore), filepath.Join(wp2, ".artignore"))
 	writeFile([]byte("abc"), filepath.Join(wp2, "a"))
@@ -130,7 +129,8 @@ e
 	InitWorkspace(wp2, repo)
 	config, _ = LoadConfig(wp2)
 	mngr2, _ := NewArtifactManager(config)
-	mngr2.Pull(PullOptions{})
+	err = mngr2.Pull(PullOptions{Mode: ChangeModeMerge})
+	assert.Empty(t, err)
 
 	data, _ := readFile(filepath.Join(wp2, "a"))
 	assert.Equal(t, "abc", string(data))

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -48,12 +48,17 @@ type PullOptions struct {
 	RefOrCommit *string
 }
 
+type PathFilter func(path string) bool
+
 type DiffOptions struct {
-	Mode        ChangeMode
-	LeftRef     string
-	LeftCommit  *Commit
-	RightRef    string
-	RightCommit *Commit
+	Mode         ChangeMode
+	LeftRef      string
+	LeftCommit   *Commit
+	RightRef     string
+	RightCommit  *Commit
+	AddFilter    PathFilter
+	ChangeFilter PathFilter
+	DeleteFilter PathFilter
 }
 
 type DiffType int


### PR DESCRIPTION
Just like `.gitigore`, the `.artignore` allows to ignore some files to version contorol.

Example
```
# Each line defines a regular expression rule

# Ignore files
^test$
^path/to/my/file$
\.DS_Store$

# Ignore folders. Use a forward slash at the end
^build/
^path/to/my/folder/
/build/

# Ignore all file with extension '.py'
\.py$
```