### PR TITLE
artiv enhancement - art clone

### DIFF
--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -36,13 +36,13 @@ var cloneCommand = &cobra.Command{
 			return
 		}
 
-		err = repository.ValidateRepository(repo)
+		_, err = repository.NewRepository(repo)
 		if err != nil {
 			exitWithError(err)
 			return
 		}
 
-		destDir, err := repository.ParseRepositoryName(repo)
+		destDir, err := parseRepoName(repo)
 		if err != nil {
 			exitWithError(err)
 			return
@@ -54,7 +54,7 @@ var cloneCommand = &cobra.Command{
 
 		baseDir := filepath.Join(cwd, destDir)
 		err = os.Mkdir(baseDir, fs.ModePerm)
-		if err == nil || (os.IsExist(err) && IsDirEmpty(baseDir)) {
+		if err == nil || (os.IsExist(err) && isDirEmpty(baseDir)) {
 			// pass
 		} else if os.IsExist(err) {
 			exitWithError(fmt.Errorf("fatal: destination path '%s' already exists and is not an empty directory.", destDir))

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+	"strings"
+
+	"github.com/infuseai/artiv/internal/core"
+	"github.com/infuseai/artiv/internal/repository"
+	"github.com/spf13/cobra"
+)
+
+var cloneCommand = &cobra.Command{
+	Use:                   "clone <repository>",
+	Short:                 "clone a workspace",
+	DisableFlagsInUseLine: true,
+	Example: `  # clone a workspace with local repository
+  art clone /path/to/mydataset
+
+  # clone a workspace with s3 repository
+  art clone s3://mybucket/path/to/mydataset`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		cwd, _ := os.Getwd()
+		repo, err := transformRepoUrl(cwd, args[0])
+		if err != nil {
+			exitWithError(err)
+			return
+		}
+
+		if strings.HasPrefix(repo, "http") {
+			exitWithError(errors.New("clone not support under http(s) repo"))
+			return
+		}
+
+		_, err = repository.NewRepository(repo)
+		if err != nil {
+			exitWithError(err)
+			return
+		}
+
+		core.InitWorkspace(cwd, repo)
+
+		config, err := core.LoadConfig("")
+		if err != nil {
+			exitWithError(err)
+			return
+		}
+
+		mngr, err := core.NewArtifactManager(config)
+		if err != nil {
+			exitWithError(err)
+			return
+		}
+
+		option := core.PullOptions{}
+		err = mngr.Pull(option)
+		if err != nil {
+			exitWithError(err)
+			return
+		}
+	},
+}
+
+func init() {
+}

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -15,7 +15,7 @@ import (
 
 var cloneCommand = &cobra.Command{
 	Use:                   "clone <repository> [<dir>]",
-	Short:                 "clone a workspace",
+	Short:                 "Clone a workspace",
 	DisableFlagsInUseLine: true,
 	Example: `  # clone a workspace with local repository
   art clone /path/to/mydataset

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -17,7 +17,7 @@ var initCommand = &cobra.Command{
 	Example: `  # Init a workspace with local repository
   art init /path/to/mydataset
 
-  # Init a workspace with s3 repoisotry
+  # Init a workspace with s3 repository
   art init s3://mybucket/path/to/mydataset`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,6 +49,7 @@ func init() {
 
 	addCommandWithGroup(GROUP_BASIC,
 		initCommand,
+		cloneCommand,
 		configCommand,
 		pullCmd,
 		pushCmd,

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -38,6 +38,24 @@ func parseRepoStr(repoAndRef string) (repoUrl string, ref string, err error) {
 	return
 }
 
+func parseRepoName(repoUrl string) (string, error) {
+	url, err := neturl.Parse(repoUrl)
+	if err != nil {
+		return "", err
+	}
+
+	if url.Path == "" {
+		return url.Hostname(), nil
+	}
+
+	name := filepath.Base(url.Path)
+	if name == "/" {
+		return url.Hostname(), nil
+	}
+
+	return name, nil
+}
+
 func transformRepoUrl(base string, repo string) (string, error) {
 	url, err := neturl.Parse(repo)
 	if err != nil {
@@ -55,7 +73,7 @@ func transformRepoUrl(base string, repo string) (string, error) {
 	return filepath.Abs(filepath.Join(base, url.Path))
 }
 
-func IsDirEmpty(dir string) bool {
+func isDirEmpty(dir string) bool {
 	f, err := os.Open(dir)
 	if err != nil {
 		return false

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -3,7 +3,9 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"io"
 	neturl "net/url"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -51,4 +53,18 @@ func transformRepoUrl(base string, repo string) (string, error) {
 	}
 
 	return filepath.Abs(filepath.Join(base, url.Path))
+}
+
+func IsDirEmpty(dir string) bool {
+	f, err := os.Open(dir)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	_, err = f.Readdirnames(1)
+	if err == io.EOF {
+		return true
+	}
+	return false
 }

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -3,7 +3,6 @@ package repository
 import (
 	"io/fs"
 	neturl "net/url"
-	"path/filepath"
 	"strings"
 
 	"github.com/infuseai/artiv/internal/meter"
@@ -50,54 +49,4 @@ func NewRepository(repo string) (Repository, error) {
 			Message: "unsupported repository",
 		}
 	}
-}
-
-func ValidateRepository(repo string) error {
-	if strings.HasPrefix(repo, "/") {
-		repo = "file://" + repo
-	}
-
-	url, err := neturl.Parse(repo)
-	if err != nil {
-		return err
-	}
-
-	if url.Scheme == "" {
-		return UnsupportedRepositoryError{
-			Message: "unsupported repository. Relative path is not allowed as a repository path",
-		}
-	}
-
-	switch url.Scheme {
-	case "file", "s3", "http":
-		return nil
-	default:
-		return UnsupportedRepositoryError{
-			Message: "unsupported repository",
-		}
-	}
-}
-
-func ParseRepositoryName(repo string) (string, error) {
-	// local repo
-	if strings.HasPrefix(repo, "/") {
-		return filepath.Base(repo), nil
-	}
-
-	// s3
-	url, err := neturl.Parse(repo)
-	if err != nil {
-		return "", err
-	}
-
-	if url.Path == "" {
-		return url.Hostname(), nil
-	}
-
-	name := filepath.Base(url.Path)
-	if name == "/" {
-		return url.Hostname(), nil
-	}
-
-	return name, nil
 }


### PR DESCRIPTION
The original flow to download a repo to a workspace is `art init` + `art pull`.

We add a `art clone` command to make it simpler.
```
Usage:
  art clone <repository> [<dir>]

Examples:
  # clone a workspace with local repository
  art clone /path/to/mydataset

  # clone a workspace with s3 repository
  art clone s3://mybucket/path/to/mydataset
```